### PR TITLE
Removal of link to random X account

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,7 +223,6 @@
     <footer class="bg-gray-900 py-6">
         <div class="container mx-auto px-4 text-center">
             <p>© 2025 Avalanche! [aV!]. All rights reserved.</p>
-            <p>Follow us on <a href="https://x.com/Avalanche" target="_blank" class="text-red-400 hover:text-red-300">@Avalanche</a></p>
         </div>
     </footer>
 </body>


### PR DESCRIPTION
We do not have a twitter/x account and this links to an existing organization we are unaffiliated with.