### PR TITLE
Use local Avalanche logo asset

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <meta property="og:title" content="Avalanche! [aV!]" />
   <meta property="og:description" content="Highlights, streams, roster, and results." />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://raw.githubusercontent.com/T24085/TribesTeams/main/aV!.png" />
+  <meta property="og:image" content="AV.png" />
 
   <!-- CSP: allow Tailwind CDN, Twitch, and YouTube (nocookie) -->
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src * data:; frame-src https://player.twitch.tv https://www.youtube-nocookie.com https://www.youtube.com; style-src 'self' https://cdn.tailwindcss.com 'unsafe-inline'; script-src 'self' https://cdn.tailwindcss.com 'unsafe-inline'">
@@ -40,7 +40,7 @@
       background:
         linear-gradient(180deg, rgba(11,18,32,.82), rgba(11,18,32,.82)),
         linear-gradient(135deg, rgba(37,99,235,.16), rgba(239,68,68,.16)),
-        url('https://raw.githubusercontent.com/T24085/TribesTeams/main/aV!.png') center / 120px repeat;
+        url('AV.png') center / 120px repeat;
     }
     /* Parallax hero & roster with tinted overlays */
     .hero-parallax { background-image:url('https://raw.githubusercontent.com/T24085/Team-Avalanche/main/3.png'); }
@@ -66,7 +66,7 @@
     <div class="bg-gradient-to-r from-brand-blue/90 via-black/70 to-brand-red/90 backdrop-blur-md border-b border-white/10">
       <div class="max-w-6xl mx-auto px-4 py-3 flex items-center gap-3">
         <a href="#home" class="flex items-center gap-3">
-          <img class="w-12 h-12 rounded-xl border border-white/30" src="https://raw.githubusercontent.com/T24085/TribesTeams/main/aV!.png" alt="Avalanche! [aV!] logo" />
+          <img class="w-12 h-12 rounded-xl border border-white/30" src="AV.png" alt="Avalanche! [aV!] logo" />
           <div class="font-extrabold tracking-tight"><span class="text-white">Avalanche!</span> <span class="text-brand-blue">[</span>aV!<span class="text-brand-red">]</span></div>
         </a>
 


### PR DESCRIPTION
## Summary
- update the Open Graph metadata, background pattern, and header logo to use the bundled AV.png asset

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dbfc1ddd5c832aad99c131f9d77017