### PR TITLE
Use AV.png for roster backdrop

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
     }
     /* Parallax hero & roster with tinted overlays */
     .hero-parallax { background-image:url('https://raw.githubusercontent.com/T24085/Team-Avalanche/main/3.png'); }
-    .roster-parallax { background-image:url('https://raw.githubusercontent.com/T24085/Team-Avalanche/main/2.jpg'); }
+    .roster-parallax { background-image:url('AV.png'); }
     .para { background-attachment: fixed; background-position:center; background-size:cover; position:relative; }
     .para::before {
       content:''; position:absolute; inset:0; z-index:0;


### PR DESCRIPTION
## Summary
- restore the Open Graph image, background tile, and header logo to their previous remote assets
- apply the bundled AV.png file as the roster section's parallax background image

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbfc1ddd5c832aad99c131f9d77017